### PR TITLE
Alias `+` as `union_all`

### DIFF
--- a/lib/active_record/setops.rb
+++ b/lib/active_record/setops.rb
@@ -8,11 +8,11 @@ module ActiveRecord
       binary_operation(Arel::Nodes::Union, other)
     end
     alias | union
-    alias + union
 
     def union_all(other)
       binary_operation(Arel::Nodes::UnionAll, other)
     end
+    alias + union_all
 
     def intersect(other)
       binary_operation(Arel::Nodes::Intersect, other)


### PR DESCRIPTION
Use `union_all` as alias for `+` since adding two arrays does not remove duplicates.

- UNION performs a DISTINCT on the result set, eliminating any duplicate rows.
- UNION ALL does not remove duplicates, and it therefore faster than UNION.

https://stackoverflow.com/questions/49925/what-is-the-difference-between-union-and-union-all